### PR TITLE
ci: fix pnpm cache issue in GitHub Actions

### DIFF
--- a/.github/workflows/tauri_release.yml
+++ b/.github/workflows/tauri_release.yml
@@ -40,8 +40,6 @@ jobs:
 
       - name: Prepare pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Sync node version and setup cache
         uses: actions/setup-node@v4
@@ -50,9 +48,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install app dependencies and build web
-        run: |
-          npm install -g pnpm
-          pnpm install && pnpm build
+        run: pnpm install && pnpm build
 
       - name: Build the app
         uses: tauri-apps/tauri-action@v0.5


### PR DESCRIPTION
- Remove explicit pnpm version (use packageManager from package.json)
- Remove redundant npm install -g pnpm
- Let pnpm/action-setup read version from package.json