### PR TITLE
feat: separate dev and prod environments

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,24 +9,24 @@ Tauri + SolidJS + TypeScript + Rust で構築されています。
 
 ### フロントエンド
 
-- **フレームワーク**: SolidJS (v1.7.3) - React に似たリアクティブ UI フレームワーク
-- **ルーティング**: @solidjs/router (v0.8.2)
-- **スタイリング**: TailwindCSS (v3.3.1)
-- **ビルドツール**: Vite (v3.2.6) + vite-plugin-solid
-- **言語**: TypeScript (v4.9.5)
+- **フレームワーク**: SolidJS (v1.9.10) - React に似たリアクティブ UI フレームワーク
+- **ルーティング**: @solidjs/router (v0.15.4)
+- **スタイリング**: TailwindCSS (v4.1.18)
+- **ビルドツール**: Vite (v7.3.1) + vite-plugin-solid
+- **言語**: TypeScript (v5.9.3)
 - **パターンマッチング**: ts-pattern (v4.2.2)
 - **動画再生**: video.js (v8.3.0)
 
 ### バックエンド (Tauri / Rust)
 
-- **Tauri**: v1.6.2 (デスクトップアプリケーションフレームワーク)
+- **Tauri**: v2.x (デスクトップアプリケーションフレームワーク)
 - **Rust Edition**: 2021
-- **gRPC**: tonic (v0.11.0) + prost (v0.12.4)
 - **非同期ランタイム**: tokio (v1.37.0)
 - **ZIP ファイル処理**: zip (v1.1.3)
 - **ファイル監視**: notify (v6.1.1)
 - **自然順ソート**: natord (v1.0.9)
-- **状態永続化**: tauri-plugin-store
+- **状態永続化**: tauri-plugin-store (v2.x)
+- **シングルインスタンス**: tauri-plugin-single-instance (v2.x)
 
 ## プロジェクト構造
 
@@ -52,17 +52,10 @@ simple-image-viewer/
 │   │   ├── app/                  # アプリケーションロジック
 │   │   │   ├── explorer.rs       # エクスプローラー機能
 │   │   │   └── viewer.rs         # ビューアー機能
-│   │   ├── grpc/                 # gRPC サーバー (プロセス間通信)
-│   │   │   ├── add_tab.rs        # タブ追加サービス
-│   │   │   ├── new_window.rs     # 新規ウィンドウサービス
-│   │   │   └── server.rs         # gRPCサーバー起動
 │   │   ├── service/              # サービス層
 │   │   │   └── app_state.rs      # アプリケーション状態管理
 │   │   └── utils/                # ユーティリティ
 │   │       └── file_utils.rs     # ファイル操作ユーティリティ
-│   └── proto/                    # Protocol Buffers定義
-│       ├── add_tab.proto
-│       └── new_window.proto
 ├── index.html                    # Viewerエントリーポイント
 ├── explorer.html                 # Explorerエントリーポイント
 └── vite.config.ts                # Vite設定 (マルチページ設定)
@@ -121,7 +114,10 @@ simple-image-viewer/
 ## 開発コマンド
 
 ```bash
-# 開発サーバー起動
+# 開発サーバー起動（開発用識別子を使用、本番版と分離）
+pnpm tauri:dev
+
+# 開発サーバー起動（本番用識別子を使用）
 pnpm tauri dev
 
 # ビルド
@@ -165,8 +161,24 @@ pnpm format-back
 
 - マルチウィンドウ対応: Viewer と Explorer は別ウィンドウで動作
 - 状態管理: アプリケーション状態は Rust 側で管理し、tauri-plugin-store で永続化
-- gRPC サーバー: ポート 50052 で起動、プロセス間通信に使用
+- シングルインスタンス: tauri-plugin-single-instance を使用、プロセス間通信に使用
 - 自動アップデート: Tauri Updater を使用、GitHub Gist 経由で配信
+
+## 開発環境と本番環境の分離
+
+開発時と本番時で環境を分離するため、以下の仕組みを導入している:
+
+| 項目 | 開発 (`pnpm tauri:dev`) | 本番 (リリースビルド) |
+|------|------------------------|----------------------|
+| App Identifier | `com.simple-image-viewer.march.dev` | `com.simple-image-viewer.march` |
+| シングルインスタンス | 開発版同士で共有 | 本番版同士で共有 |
+| Viewer タイトル | `Simple Image Viewer [DEV]` | `Simple Image Viewer` |
+| Explorer タイトル | `Image Explorer [DEV]` | `Image Explorer` |
+| 状態ファイル | `{AppData}/simple-image-viewer-dev/state.json` | `{AppData}/simple-image-viewer/state.json` |
+
+- 設定ファイル: `src-tauri/tauri.dev.conf.json` で開発用の identifier を定義
+- 実行時判定: `cfg!(debug_assertions)` でビルドモードを判定し、パス・タイトルを切り替え
+- 詳細: `docs/dev-prod-environment-separation.md` を参照
 
 ## JSX の記法
 

--- a/docs/dev-prod-environment-separation.md
+++ b/docs/dev-prod-environment-separation.md
@@ -1,0 +1,147 @@
+# 開発環境と本番環境の分離 実行計画
+
+## 背景・課題
+
+アプリを実用しながら開発を行う際、以下の問題が発生していた：
+
+1. **シングルインスタンス制約**: 本番版が起動中だと開発版が起動できない（逆も同様）
+2. **state.json の共有**: 開発版と本番版で状態ファイルが共有され、開発中の変更が本番環境に影響する
+
+## 解決方針
+
+Tauri の設定マージ機能（`--config` フラグ）と Rust の `cfg!(debug_assertions)` を組み合わせて、開発環境と本番環境を完全に分離する。
+
+### 分離される項目
+
+| 項目 | 開発 (`tauri dev`) | 本番 (リリースビルド) |
+|------|-------------------|----------------------|
+| App Identifier | `com.simple-image-viewer.march.dev` | `com.simple-image-viewer.march` |
+| シングルインスタンス | 開発版同士で共有 | 本番版同士で共有 |
+| Viewer タイトル | `Simple Image Viewer [DEV]` | `Simple Image Viewer` |
+| Explorer タイトル | `Image Explorer [DEV]` | `Image Explorer` |
+| 状態ファイル | `{AppData}/simple-image-viewer-dev/state.json` | `{AppData}/simple-image-viewer/state.json` |
+
+## 実装計画
+
+### Step 1: 開発用設定ファイルの作成
+
+**ファイル**: `src-tauri/tauri.dev.conf.json`
+
+```json
+{
+  "identifier": "com.simple-image-viewer.march.dev",
+  "productName": "simple-image-viewer-dev",
+  "app": {
+    "windows": [
+      {
+        "label": "viewer-0",
+        "title": "Simple Image Viewer [DEV]"
+      }
+    ]
+  }
+}
+```
+
+**効果**:
+- 開発用の異なる `identifier` により、シングルインスタンスのミューテックス/ソケット名が本番と分離される
+- 初期ウィンドウのタイトルが `[DEV]` 付きになる
+
+### Step 2: npm scripts の更新
+
+**ファイル**: `package.json`
+
+```json
+{
+  "scripts": {
+    "tauri:dev": "tauri dev --config src-tauri/tauri.dev.conf.json"
+  }
+}
+```
+
+**使い方**:
+- 開発時: `pnpm tauri:dev`（開発用識別子を使用）
+- 従来通り: `pnpm tauri dev`（本番用識別子を使用、テスト用途）
+
+### Step 3: 状態ファイルパスの分離
+
+**ファイル**: `src-tauri/src/app/mod.rs`
+
+ヘルパー関数を追加:
+
+```rust
+/// Returns the app directory name based on build mode
+fn get_app_dir_name() -> &'static str {
+    if cfg!(debug_assertions) {
+        "simple-image-viewer-dev"
+    } else {
+        "simple-image-viewer"
+    }
+}
+```
+
+状態ファイルの読み込み・保存箇所で使用:
+
+```rust
+// 読み込み時
+let save_path = save_dir.join(get_app_dir_name()).join("state.json");
+
+// 保存時
+let app_dir = dir.join(get_app_dir_name());
+```
+
+### Step 4: ウィンドウタイトルの分岐
+
+**ファイル**: `src-tauri/src/app/mod.rs`
+
+ヘルパー関数を追加:
+
+```rust
+/// Returns the viewer window title based on build mode
+fn get_viewer_title() -> &'static str {
+    if cfg!(debug_assertions) {
+        "Simple Image Viewer [DEV]"
+    } else {
+        "Simple Image Viewer"
+    }
+}
+
+/// Returns the explorer window title based on build mode
+fn get_explorer_title() -> &'static str {
+    if cfg!(debug_assertions) {
+        "Image Explorer [DEV]"
+    } else {
+        "Image Explorer"
+    }
+}
+```
+
+動的に作成されるウィンドウで使用:
+
+```rust
+// Viewer ウィンドウ
+.title(get_viewer_title())
+
+// Explorer ウィンドウ
+.title(get_explorer_title())
+```
+
+## 変更対象ファイル一覧
+
+1. `src-tauri/tauri.dev.conf.json` - 新規作成
+2. `package.json` - scripts に `tauri:dev` を追加
+3. `src-tauri/src/app/mod.rs` - ヘルパー関数追加、パス・タイトルの分岐
+
+## 動作確認手順
+
+1. 本番版をインストール・起動
+2. `pnpm tauri:dev` で開発版を起動
+3. 両方が同時に起動できることを確認
+4. 開発版のウィンドウタイトルに `[DEV]` が付いていることを確認
+5. 開発版で状態を変更し、本番版に影響がないことを確認
+6. `%APPDATA%/simple-image-viewer-dev/state.json` が作成されることを確認
+
+## 注意事項
+
+- `pnpm tauri dev`（従来コマンド）は本番用識別子を使用するため、本番版と競合する
+- 開発時は `pnpm tauri:dev` を使用すること
+- state.json のスキーマが変わった場合、開発用・本番用それぞれで初期化が必要

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "vite build",
     "serve": "vite preview",
     "tauri": "tauri",
+    "tauri:dev": "tauri dev --config src-tauri/tauri.dev.conf.json",
     "lint": "eslint src/",
     "format-web": "prettier --write \"src/**/*.{js,jsx,ts,tsx,css,md,json}\" ",
     "format-back": "cd src-tauri && cargo fmt && cargo clippy --fix --allow-dirty --allow-staged",

--- a/src-tauri/src/app/explorer.rs
+++ b/src-tauri/src/app/explorer.rs
@@ -55,7 +55,7 @@ pub(crate) async fn open_new_explorer<'a>(
     let label = add_explorer_state(&state).await?;
     let explorer_state = add_explorer_tab_state(&label, &state).await?;
     WebviewWindowBuilder::new(&app, &label, WebviewUrl::App("explorer.html".into()))
-        .title("Image Explorer")
+        .title(super::get_explorer_title())
         .build()
         .map_err(|_| "system unavailable".to_string())?;
     app.emit_to(&label, "explorer-state-changed", &explorer_state)

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -58,9 +58,36 @@ impl Default for SavedState {
     }
 }
 
+/// Returns the app directory name based on build mode
+fn get_app_dir_name() -> &'static str {
+    if cfg!(debug_assertions) {
+        "simple-image-viewer-dev"
+    } else {
+        "simple-image-viewer"
+    }
+}
+
+/// Returns the viewer window title based on build mode
+fn get_viewer_title() -> &'static str {
+    if cfg!(debug_assertions) {
+        "Simple Image Viewer [DEV]"
+    } else {
+        "Simple Image Viewer"
+    }
+}
+
+/// Returns the explorer window title based on build mode
+fn get_explorer_title() -> &'static str {
+    if cfg!(debug_assertions) {
+        "Image Explorer [DEV]"
+    } else {
+        "Image Explorer"
+    }
+}
+
 pub fn create_viewer() -> Builder<Wry> {
     let save_dir = dirs::data_dir().unwrap_or_default();
-    let save_path = save_dir.join("simple-image-viewer").join("state.json");
+    let save_path = save_dir.join(get_app_dir_name()).join("state.json");
     let saved_state = if let Ok(data) = std::fs::read_to_string(save_path.clone()) {
         serde_json::from_str::<SavedState>(&data).unwrap_or_default()
     } else {
@@ -103,7 +130,7 @@ pub fn create_viewer() -> Builder<Wry> {
                             &label,
                             WebviewUrl::App("index.html".into()),
                         )
-                        .title("Simple Image Viewer")
+                        .title(get_viewer_title())
                         .maximized(true)
                         .build();
                     }
@@ -136,7 +163,7 @@ pub fn create_viewer() -> Builder<Wry> {
                         label.clone(),
                         WebviewUrl::App("index.html".into()),
                     )
-                    .title("Simple Image Viewer")
+                    .title(get_viewer_title())
                     .maximized(true)
                     .build()
                     .unwrap();
@@ -155,7 +182,7 @@ pub fn create_viewer() -> Builder<Wry> {
                         label.clone(),
                         WebviewUrl::App("explorer.html".into()),
                     )
-                    .title("Image Explorer")
+                    .title(get_explorer_title())
                     .build()
                     .unwrap();
                 });
@@ -181,7 +208,7 @@ pub fn create_viewer() -> Builder<Wry> {
                         explorers,
                     };
                     let dir = dirs::data_dir().unwrap_or_default();
-                    let app_dir = dir.join("simple-image-viewer");
+                    let app_dir = dir.join(get_app_dir_name());
                     let _ = std::fs::create_dir_all(&app_dir);
                     let path = app_dir.join("state.json");
                     let _ = std::fs::write(

--- a/src-tauri/tauri.dev.conf.json
+++ b/src-tauri/tauri.dev.conf.json
@@ -1,0 +1,12 @@
+{
+  "identifier": "com.simple-image-viewer.march.dev",
+  "productName": "simple-image-viewer-dev",
+  "app": {
+    "windows": [
+      {
+        "label": "viewer-0",
+        "title": "Simple Image Viewer [DEV]"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
- Add tauri.dev.conf.json with dev-specific identifier
- Add pnpm tauri:dev script to use dev config
- Separate state.json paths (simple-image-viewer-dev vs simple-image-viewer)
- Add [DEV] suffix to window titles in debug builds
- Update copilot-instructions.md with current library versions
- Remove gRPC references (replaced by tauri-plugin-single-instance)
- Add docs/dev-prod-environment-separation.md