### PR TITLE
Fix/memory-leak-and-resource-management

### DIFF
--- a/docs/memory-leak-fix-plan.md
+++ b/docs/memory-leak-fix-plan.md
@@ -1,0 +1,243 @@
+# メモリリーク・リソース管理問題の修正計画
+
+作成日: 2026-01-12
+
+## 概要
+
+アプリケーションで以下の症状が報告されている:
+- 長時間起動しているとき強制終了する
+- Viewerでタブを多く開いているとき強制終了する
+- Explorerのファイル読み込みなどで重い処理中にViewerを動かしたとき強制終了する
+
+調査の結果、以下の問題が特定された。
+
+## 発見された問題一覧
+
+| # | 影響度 | 問題 | ファイル |
+|---|--------|------|----------|
+| 1 | 🔴 高 | ファイル監視(notify)のリソースリーク | `src-tauri/src/app/viewer.rs` |
+| 2 | 🔴 高 | ZIP読み込み時のメモリ爆発 | `src-tauri/src/app/viewer.rs` |
+| 3 | 🔴 高 | get_compressed_file_treeでのZIP全体読み込み | `src-tauri/src/app/explorer.rs` |
+| 4 | 🟡 中 | ViewerTabのイベントリスナー解除漏れ | `src/pages/viewer/ViewerTab.tsx` |
+| 5 | 🟡 中 | ExplorerTabのイベントリスナー解除漏れ | `src/pages/explorer/ExplorerTab.tsx` |
+| 6 | 🟡 中 | タブごとのFileTree重複保持 | `src-tauri/src/service/app_state.rs` |
+| 7 | 🟡 中 | video.jsのdispose処理欠如 | `src/pages/viewer/ViewerTab.tsx` |
+| 8 | 🟢 低 | 非同期ロックの長時間保持 | 複数ファイル |
+
+---
+
+## 問題詳細と修正方針
+
+### 問題1: ファイル監視(notify)のリソースリーク 🔴
+
+**現状のコード:**
+```rust
+#[tauri::command]
+pub(crate) fn subscribe_dir_notification(filepath: String, app: AppHandle) {
+    let path_inner = filepath.clone();
+    recommended_watcher(move |res| match res {
+        // ...
+    })
+    .map_or_else(
+        |_| (),
+        |mut watcher| {
+            watcher
+                .watch(Path::new(&filepath), RecursiveMode::Recursive)
+                .unwrap_or(())
+        },
+    );
+    // ← watcher がここでスコープを抜けてドロップされるが、内部スレッドは停止しない！
+}
+```
+
+**問題点:**
+1. `watcher`が関数終了時にスコープを抜けてドロップされるが、notifyの内部監視スレッドは停止しない
+2. タブを開くたびに`subscribe_dir_notification`が呼ばれ、監視スレッドが累積
+3. タブを閉じても監視は解除されない
+4. 長時間使用で数百〜数千の監視スレッドが蓄積し、メモリ・リソース枯渇
+
+**修正方針:**
+- `AppState`に`HashMap<String, RecommendedWatcher>`を追加
+- パスごとにwatcherを管理し、参照カウントで共有
+- タブ削除時に対応するwatcherを適切に`drop`
+
+**修正ファイル:**
+- `src-tauri/src/service/app_state.rs`
+- `src-tauri/src/app/viewer.rs`
+
+---
+
+### 問題2, 3: ZIP読み込み時のメモリ爆発 🔴
+
+**現状のコード:**
+```rust
+// viewer.rs - read_image_in_zip
+let file = std::fs::read(path).unwrap_or_default(); // ZIPファイル全体をメモリに読み込み
+let zip = zip::ZipArchive::new(std::io::Cursor::new(file));
+
+// explorer.rs - get_compressed_file_tree
+let file = std::fs::read(filepath).unwrap_or_default(); // 同様
+```
+
+**問題点:**
+1. `std::fs::read`でZIPファイル全体(数百MB〜数GB)をメモリに読み込む
+2. 展開した画像データもメモリに保持
+3. Base64エンコードでさらにメモリ使用量が約1.33倍に
+4. 大きなZIPファイルで画像を連続で見ると急激にメモリ増加
+
+**修正方針:**
+- `std::fs::File`と`BufReader`を使用してストリーミング読み込みに変更
+- ZIPアーカイブを直接ファイルから開く
+
+**修正後のコード:**
+```rust
+use std::fs::File;
+use std::io::BufReader;
+
+let file = File::open(&path).map_err(|e| e.to_string())?;
+let reader = BufReader::new(file);
+let mut zip = zip::ZipArchive::new(reader).map_err(|e| e.to_string())?;
+```
+
+**修正ファイル:**
+- `src-tauri/src/app/viewer.rs`
+- `src-tauri/src/app/explorer.rs`
+
+---
+
+### 問題4, 5: イベントリスナー解除漏れ 🟡
+
+**現状のコード (ViewerTab.tsx):**
+```tsx
+appWindow
+  .listen('viewer-tab-state-changed', (event) => {
+    // ...
+  })
+  .then((unListen) => (unListenRef = unListen));
+
+onCleanup(() => {
+  unListenRef && unListenRef();
+});
+```
+
+**問題点:**
+1. `listen()`は非同期で、Promiseが解決する前にタブが閉じられると`unListenRef`が`undefined`のまま
+2. 結果としてイベントリスナーが解除されない
+3. タブの素早い開閉で累積
+
+**修正方針:**
+- `onMount`内で`await`を使用してリスナー登録を待つ
+- または解除関数の配列を使用して確実にクリーンアップ
+
+**修正後のコード:**
+```tsx
+let unListenRef: UnlistenFn | undefined;
+
+onMount(async () => {
+  unListenRef = await appWindow.listen('viewer-tab-state-changed', (event) => {
+    // ...
+  });
+});
+
+onCleanup(() => {
+  unListenRef?.();
+});
+```
+
+**修正ファイル:**
+- `src/pages/viewer/ViewerTab.tsx`
+- `src/pages/explorer/ExplorerTab.tsx`
+
+---
+
+### 問題6: タブごとのFileTree重複保持 🟡
+
+**現状のコード:**
+```rust
+pub struct ViewerTabState {
+    pub tree: Vec<FileTree>, // ディレクトリ全体のツリー構造を各タブで保持
+}
+```
+
+**問題点:**
+- 各タブが`tree`全体をメモリに保持
+- 大きなディレクトリ（数千〜数万ファイル）を開くと、各タブで大量のメモリを消費
+- 同じディレクトリを複数タブで開くとデータが重複
+
+**修正方針:**
+- 今回は影響度を考慮し、優先度を下げる
+- 将来的には`Arc<Vec<FileTree>>`による共有、またはディレクトリパスをキーとしたキャッシュを検討
+
+**対応:** 今回は見送り（将来課題として記録）
+
+---
+
+### 問題7: video.jsのdispose処理欠如 🟡
+
+**現状のコード:**
+```tsx
+<Match when={props.viewing?.file_type === 'Video'}>
+  <video
+    class="video-js vjs-theme-fantasy w-full h-full object-contain"
+    controls
+    preload="auto"
+    src={data()}
+  />
+</Match>
+```
+
+**問題点:**
+1. video.jsのCSSをインポートしているが、実際には`videojs()`での初期化がない
+2. 素のHTML5 `<video>`要素を使用している
+3. 動画切り替え時にブラウザの動画バッファがメモリに残る可能性
+
+**修正方針:**
+- video.jsを正しく初期化するか、video.jsを削除して軽量化するか選択
+- 今回は軽量化を選択し、video.jsのCSSのみ使用を継続
+- `<video>`要素に`ref`を設定し、ソース変更時に明示的に`load()`を呼ぶ
+
+**修正ファイル:**
+- `src/pages/viewer/ViewerTab.tsx`
+
+---
+
+### 問題8: 非同期ロックの長時間保持 🟢
+
+**現状のコード:**
+```rust
+pub(crate) async fn move_explorer_forward(...) -> Result<(), String> {
+    let mut explorers = state.explorers.lock().await; // ロック取得
+    // ...
+    let thumbnails = explore_path(&path, page)?; // I/O処理（ロック保持中）
+    let end = get_page_count(&path).await?; // 非同期I/O（ロック保持中）
+    // ...
+}
+```
+
+**問題点:**
+1. ファイルI/O処理中にMutexロックを保持し続ける
+2. 重い処理中に他のコマンドがブロックされる
+
+**修正方針:**
+- 今回は影響度を考慮し、優先度を下げる
+- 将来的にはロックを最小限に保持するパターンに変更
+
+**対応:** 今回は見送り（将来課題として記録）
+
+---
+
+## 実装順序
+
+1. **問題1**: watcher管理をAppStateに移行（最優先・クラッシュの主要因）
+2. **問題2, 3**: ZIP読み込みをストリーミング化
+3. **問題4, 5**: イベントリスナー解除を確実に
+4. **問題7**: video要素のリソース管理改善
+
+---
+
+## 将来の改善課題
+
+- [ ] FileTreeの共有参照化（問題6）
+- [ ] Mutexロック保持時間の最適化（問題8）
+- [ ] ZIPファイルのLRUキャッシュ導入
+- [ ] 画像データのメモリキャッシュ上限設定

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -22,8 +22,9 @@ use crate::{
             change_active_viewer, change_active_viewer_tab, change_viewing,
             get_filenames_inner_zip, move_backward, move_forward, open_file_image,
             open_image_dialog, open_new_viewer, open_new_viewer_tab, read_image_in_zip,
-            remove_viewer_tab, request_restore_viewer_state, request_restore_viewer_tab_state,
-            subscribe_dir_notification, unsubscribe_dir_notification,
+            refresh_viewer_tab_tree, remove_viewer_tab, request_restore_viewer_state,
+            request_restore_viewer_tab_state, subscribe_dir_notification,
+            unsubscribe_dir_notification,
         },
     },
     service::app_state::{
@@ -268,5 +269,6 @@ pub fn create_viewer() -> Builder<Wry> {
             move_forward,
             move_backward,
             request_restore_viewer_tab_state,
+            refresh_viewer_tab_tree,
         ])
 }

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -23,7 +23,7 @@ use crate::{
             get_filenames_inner_zip, move_backward, move_forward, open_file_image,
             open_image_dialog, open_new_viewer, open_new_viewer_tab, read_image_in_zip,
             remove_viewer_tab, request_restore_viewer_state, request_restore_viewer_tab_state,
-            subscribe_dir_notification,
+            subscribe_dir_notification, unsubscribe_dir_notification,
         },
     },
     service::app_state::{
@@ -98,6 +98,7 @@ pub fn create_viewer() -> Builder<Wry> {
         active: Mutex::new(saved_state.active),
         viewers: Mutex::new(saved_state.viewers.clone()),
         explorers: Mutex::new(saved_state.explorers.clone()),
+        watchers: Mutex::new(std::collections::HashMap::new()),
     };
     let viewers_to_restore = saved_state.viewers.clone();
     let explorers_to_restore = saved_state.explorers.clone();
@@ -240,6 +241,7 @@ pub fn create_viewer() -> Builder<Wry> {
             get_filenames_inner_zip,
             read_image_in_zip,
             subscribe_dir_notification,
+            unsubscribe_dir_notification,
             open_new_viewer,
             open_new_viewer_tab,
             open_image_dialog,

--- a/src-tauri/src/app/viewer.rs
+++ b/src-tauri/src/app/viewer.rs
@@ -1,6 +1,8 @@
 use base64::{engine::general_purpose, Engine as _};
 use notify::{recommended_watcher, RecursiveMode, Watcher};
-use std::{io::Read, path::Path};
+use std::fs::File as StdFile;
+use std::io::{BufReader, Read};
+use std::path::Path;
 use tauri::{AppHandle, Emitter, State, WebviewWindow};
 
 use crate::service::app_state::{
@@ -8,10 +10,26 @@ use crate::service::app_state::{
     open_file_pick_dialog, remove_viewer_tab_state, ActiveTab, ActiveViewer, AppState, File,
 };
 
+/// ディレクトリ監視を開始する
+/// watcherはAppStateで管理し、同じパスへの監視は参照カウントで共有する
 #[tauri::command]
-pub(crate) fn subscribe_dir_notification(filepath: String, app: AppHandle) {
+pub(crate) async fn subscribe_dir_notification(
+    filepath: String,
+    _tab_key: String,
+    state: State<'_, AppState>,
+    app: AppHandle,
+) -> Result<(), String> {
+    let mut watchers = state.watchers.lock().await;
+    
+    // 既に同じパスの監視がある場合は参照カウントを増やすだけ
+    if let Some((_, ref_count)) = watchers.get_mut(&filepath) {
+        *ref_count += 1;
+        return Ok(());
+    }
+    
+    // 新しいwatcherを作成
     let path_inner = filepath.clone();
-    recommended_watcher(move |res| match res {
+    let watcher = recommended_watcher(move |res| match res {
         Ok(_) => {
             app.emit("directory-tree-changed", &path_inner)
                 .unwrap_or_default();
@@ -24,51 +42,63 @@ pub(crate) fn subscribe_dir_notification(filepath: String, app: AppHandle) {
             .unwrap_or_default();
         }
     })
-    .map_or_else(
-        |_| (),
-        |mut watcher| {
-            watcher
-                .watch(Path::new(&filepath), RecursiveMode::Recursive)
-                .unwrap_or(())
-        },
-    );
+    .map_err(|e| format!("failed to create watcher: {}", e))?;
+    
+    let mut watcher = watcher;
+    watcher
+        .watch(Path::new(&filepath), RecursiveMode::Recursive)
+        .map_err(|e| format!("failed to watch directory: {}", e))?;
+    
+    watchers.insert(filepath, (watcher, 1));
+    Ok(())
 }
 
+/// ディレクトリ監視を解除する
+/// 参照カウントが0になった場合のみwatcherを削除
 #[tauri::command]
-pub(crate) fn open_file_image(filepath: String) -> String {
-    let img = std::fs::read(filepath).unwrap_or_default();
-    general_purpose::STANDARD_NO_PAD.encode(img)
-}
-
-#[tauri::command]
-pub(crate) fn get_filenames_inner_zip(filepath: String) -> Vec<String> {
-    let file = std::fs::read(filepath).unwrap_or_default();
-    let zip = zip::ZipArchive::new(std::io::Cursor::new(file));
-    let mut files = zip
-        .map(|f| f.file_names().map(|s| s.into()).collect::<Vec<String>>())
-        .unwrap_or_default();
-    files.sort();
-    files
-}
-
-#[tauri::command]
-pub(crate) fn read_image_in_zip(path: String, filename: String) -> String {
-    let file = std::fs::read(path).unwrap_or_default();
-    let zip = zip::ZipArchive::new(std::io::Cursor::new(file));
-    match zip {
-        Ok(mut e) => {
-            let inner = e.by_name(&filename);
-            match inner {
-                Ok(mut f) => {
-                    let mut buf = vec![];
-                    f.read_to_end(&mut buf).unwrap_or_default();
-                    general_purpose::STANDARD_NO_PAD.encode(&buf)
-                }
-                Err(_) => "".into(),
-            }
+pub(crate) async fn unsubscribe_dir_notification(
+    filepath: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let mut watchers = state.watchers.lock().await;
+    
+    if let Some((_, ref_count)) = watchers.get_mut(&filepath) {
+        *ref_count -= 1;
+        if *ref_count == 0 {
+            watchers.remove(&filepath);
         }
-        Err(_) => "".into(),
     }
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) fn open_file_image(filepath: String) -> Result<String, String> {
+    let img = std::fs::read(&filepath).map_err(|e| format!("failed to read image: {}", e))?;
+    Ok(general_purpose::STANDARD_NO_PAD.encode(img))
+}
+
+/// ZIPファイル内のファイル名一覧を取得（ストリーミング読み込み）
+#[tauri::command]
+pub(crate) fn get_filenames_inner_zip(filepath: String) -> Result<Vec<String>, String> {
+    let file = StdFile::open(&filepath).map_err(|e| format!("failed to open zip: {}", e))?;
+    let reader = BufReader::new(file);
+    let zip = zip::ZipArchive::new(reader).map_err(|e| format!("failed to read zip: {}", e))?;
+    let mut files: Vec<String> = zip.file_names().map(|s| s.into()).collect();
+    files.sort();
+    Ok(files)
+}
+
+/// ZIP内の画像をBase64で読み込み（ストリーミング読み込み）
+#[tauri::command]
+pub(crate) fn read_image_in_zip(path: String, filename: String) -> Result<String, String> {
+    let file = StdFile::open(&path).map_err(|e| format!("failed to open zip: {}", e))?;
+    let reader = BufReader::new(file);
+    let mut zip = zip::ZipArchive::new(reader).map_err(|e| format!("failed to read zip: {}", e))?;
+    
+    let mut inner = zip.by_name(&filename).map_err(|e| format!("file not found in zip: {}", e))?;
+    let mut buf = Vec::with_capacity(inner.size() as usize);
+    inner.read_to_end(&mut buf).map_err(|e| format!("failed to read file: {}", e))?;
+    Ok(general_purpose::STANDARD_NO_PAD.encode(&buf))
 }
 
 #[tauri::command]

--- a/src-tauri/src/service/app_state.rs
+++ b/src-tauri/src/service/app_state.rs
@@ -319,8 +319,22 @@ pub(crate) async fn open_file_pick_dialog(app: &tauri::AppHandle) -> Result<Stri
     }
 }
 
+/// ディレクトリのファイルツリーを再構築する
+/// ディレクトリ変更通知を受けた際にフロントエンドから呼び出される
+pub(crate) fn rebuild_file_tree(path: &str, is_compressed: bool) -> Vec<FileTree> {
+    if is_compressed {
+        get_compressed_file_tree(&path.to_string())
+    } else {
+        let mut key_count = 0;
+        get_file_tree(&path.to_string(), &mut key_count)
+    }
+}
+
 fn get_file_tree(path: &String, key_count: &mut i32) -> Vec<FileTree> {
-    let dirs = std::fs::read_dir(path).unwrap();
+    let dirs = match std::fs::read_dir(path) {
+        Ok(d) => d,
+        Err(_) => return vec![],
+    };
     let mut files = dirs
         .map(|f| {
             let filepath = f.unwrap().path();

--- a/src-tauri/src/service/app_state.rs
+++ b/src-tauri/src/service/app_state.rs
@@ -1,4 +1,6 @@
+use notify::RecommendedWatcher;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs::read_dir;
 use sysinfo::Disks;
 use tauri::State;
@@ -89,6 +91,8 @@ pub struct AppState {
     pub active: Mutex<ActiveViewer>,
     pub viewers: Mutex<Vec<ViewerState>>,
     pub explorers: Mutex<Vec<ExplorerState>>,
+    /// ディレクトリ監視のwatcher管理 (path -> (watcher, 参照カウント))
+    pub watchers: Mutex<HashMap<String, (RecommendedWatcher, usize)>>,
 }
 
 pub(crate) async fn add_viewer_state<'a>(state: &State<'a, AppState>) -> Result<String, String> {
@@ -361,13 +365,19 @@ fn get_file_tree(path: &String, key_count: &mut i32) -> Vec<FileTree> {
     files
 }
 
+/// ZIPファイル内のファイルツリーを取得（ストリーミング読み込み）\n
 fn get_compressed_file_tree(filepath: &String) -> Vec<FileTree> {
     let mut key_count = 0;
-    let file = std::fs::read(filepath).unwrap_or_default();
-    let zip = zip::ZipArchive::new(std::io::Cursor::new(file));
-    let mut files = zip
-        .map(|f| f.file_names().map(|s| s.into()).collect::<Vec<String>>())
-        .unwrap_or_default();
+    let file = match std::fs::File::open(filepath) {
+        Ok(f) => f,
+        Err(_) => return vec![],
+    };
+    let reader = std::io::BufReader::new(file);
+    let zip = match zip::ZipArchive::new(reader) {
+        Ok(z) => z,
+        Err(_) => return vec![],
+    };
+    let mut files: Vec<String> = zip.file_names().map(|s| s.into()).collect();
     files.sort();
     files
         .iter()

--- a/src/features/Image/ImageCanvas/index.tsx
+++ b/src/features/Image/ImageCanvas/index.tsx
@@ -29,6 +29,7 @@ export const ImageCanvas: Component<Props> = (props) => {
   const [initialPosition, setInitialPosition] = createSignal({ x: 0, y: 0 });
   const [imageScale, setImageScale] = createSignal<number>(1);
   const [position, setPosition] = createSignal({ x: 0, y: 0 });
+  let videoRef: HTMLVideoElement | undefined;
 
   const handleWheel = (e: WheelEvent) => {
     e.preventDefault();
@@ -55,6 +56,12 @@ export const ImageCanvas: Component<Props> = (props) => {
 
   onCleanup(() => {
     document.removeEventListener('keydown', handleOnKeyDown, false);
+    // 動画リソースを明示的に解放
+    if (videoRef) {
+      videoRef.pause();
+      videoRef.src = '';
+      videoRef.load();
+    }
   });
 
   const handlePositionChange = (newPosition: { x: number; y: number }) => {
@@ -120,6 +127,15 @@ export const ImageCanvas: Component<Props> = (props) => {
     ),
   );
 
+  // 動画ソース変更時に前の動画リソースを解放し、新しいソースを読み込む
+  createEffect(
+    on(data, () => {
+      if (videoRef && props.viewing?.file_type === 'Video') {
+        videoRef.load();
+      }
+    }),
+  );
+
   return (
     <div class="flex flex-row content-center" style={{ flex: 4 }}>
       <div
@@ -153,6 +169,7 @@ export const ImageCanvas: Component<Props> = (props) => {
             </Match>
             <Match when={props.viewing?.file_type === 'Video'}>
               <video
+                ref={videoRef}
                 class="video-js vjs-theme-fantasy w-full h-full object-contain"
                 controls
                 preload="auto"


### PR DESCRIPTION
## 修正内容

### Rust側
- rebuild_file_tree関数を追加（app_state.rs）
- refresh_viewer_tab_treeコマンドを追加（viewer.rs）
  - ディレクトリ変更通知を受けてファイルツリーを再構築
  - 現在表示中のファイルが存在するか確認し、なければクリア
- get_file_treeのエラーハンドリングを改善（unwrap -> match）

### フロントエンド側
- ViewerTab.tsxでdirectory-tree-changedイベントをリッスン
- 監視対象パスと一致する場合にrefresh_viewer_tab_treeを呼び出し
- イベントリスナーの変数名を明確化（unListenTabStateRef, unListenDirChangedRef）

## 動作フロー
1. タブ作成時にsubscribe_dir_notificationでディレクトリ監視を開始
2. ファイル変更時にnotifyがdirectory-tree-changedイベントを発火
3. フロントエンドがイベントを受け取り、該当タブならrefresh_viewer_tab_treeを呼び出し
4. Rust側でツリーを再構築してviewer-tab-state-changedで更新を通知
5. タブクローズ時にunsubscribe_dir_notificationで監視を解除