### PR TITLE
feat: ExplorerとViewerの連携機能を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
       "eslint --fix"
     ],
     "src-tauri/**/*.rs": [
-      "cd src-tauri && cargo fmt --",
-      "cd src-tauri && cargo clippy --fix --allow-dirty --allow-staged --"
+      "sh -c 'cd src-tauri && cargo fmt'",
+      "sh -c 'cd src-tauri && cargo clippy --fix --allow-dirty --allow-staged'"
     ]
   },
   "license": "MIT",

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -20,11 +20,11 @@ use crate::{
         },
         viewer::{
             change_active_viewer, change_active_viewer_tab, change_viewing,
-            get_filenames_inner_zip, move_backward, move_forward, open_file_image,
-            open_image_dialog, open_new_viewer, open_new_viewer_tab, read_image_in_zip,
-            refresh_viewer_tab_tree, remove_viewer_tab, request_restore_viewer_state,
-            request_restore_viewer_tab_state, subscribe_dir_notification,
-            unsubscribe_dir_notification,
+            close_viewer_tabs_by_directory, get_active_viewer_directory, get_filenames_inner_zip,
+            move_backward, move_forward, open_file_image, open_image_dialog, open_new_viewer,
+            open_new_viewer_tab, read_image_in_zip, refresh_viewer_tab_tree, remove_viewer_tab,
+            request_restore_viewer_state, request_restore_viewer_tab_state,
+            subscribe_dir_notification, unsubscribe_dir_notification,
         },
     },
     service::app_state::{
@@ -270,5 +270,7 @@ pub fn create_viewer() -> Builder<Wry> {
             move_backward,
             request_restore_viewer_tab_state,
             refresh_viewer_tab_tree,
+            get_active_viewer_directory,
+            close_viewer_tabs_by_directory,
         ])
 }

--- a/src-tauri/src/utils/file_utils.rs
+++ b/src-tauri/src/utils/file_utils.rs
@@ -119,3 +119,8 @@ pub(crate) fn get_any_extensions() -> Vec<String> {
     extensions.extend(get_compressed_extensions());
     extensions
 }
+
+/// パスを正規化（Windowsのバックスラッシュを統一）
+pub(crate) fn normalize_path(path: &str) -> String {
+    path.replace('\\', "/").to_lowercase()
+}

--- a/src/features/Folder/routes/Folder.tsx
+++ b/src/features/Folder/routes/Folder.tsx
@@ -8,6 +8,7 @@ import { convertFileSrc } from '@tauri-apps/api/core';
 type Props = {
   thumb: Thumbnail;
   showMarkAsRead: boolean;
+  isHighlighted: boolean;
   onMarkedAsRead: (path: string) => void;
   onClick: (thumb: Thumbnail) => void;
 };
@@ -20,7 +21,13 @@ export const Folder: Component<Props> = (props) => {
       props.thumb.thumbpath ? convertFileSrc(props.thumb.thumbpath) : fallback,
   );
   return (
-    <div class="flex flex-col w-48 h-48 overflow-hidden relative">
+    <div
+      class={`flex flex-col w-48 h-48 overflow-hidden relative rounded-lg transition-all ${
+        props.isHighlighted
+          ? 'bg-blue-900/40 ring-2 ring-blue-500'
+          : 'bg-transparent'
+      }`}
+    >
       <Show when={props.showMarkAsRead}>
         <button
           class={`absolute top-0 right-4 ${


### PR DESCRIPTION
- ExplorerでアクティブなViewerのディレクトリをハイライト表示
  - アクティブなViewerのアクティブなタブで開いているディレクトリをExplorer側で視覚的に強調
  - リアルタイムでViewerのタブ切り替えに追従
- Explorerでチェックしたディレクトリに対応するViewerタブを自動的に閉じる
  - 全てのViewerウィンドウ（バックグラウンド含む）で該当ディレクトリのタブを閉じる

実装内容:
- Rust側: get_active_viewer_directory, close_viewer_tabs_by_directory, normalize_path関数を追加
- Viewer側: タブ切り替え時に全Explorerへイベント送信
- Explorer側: active-viewer-directory-changedイベントをlistenして自動更新
- Folder: isHighlightedプロパティを追加し、青背景+青リングでハイライト表示
- lint-staged設定を修正（Windows環境でのcargo実行エラーを解決）