### PR TITLE
fix: Fix recommendation rebuild not starting in Tauri v2

### DIFF
--- a/.github/workflows/tauri_release.yml
+++ b/.github/workflows/tauri_release.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Pull LFS files
+        run: git lfs pull
 
       - name: Install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-22.04'

--- a/src-tauri/src/service/types.rs
+++ b/src-tauri/src/service/types.rs
@@ -41,5 +41,6 @@ pub struct AppState {
     /// SQLite データベース (Phase 2: リコメンド基盤)
     pub db: Arc<Database>,
     /// CLIP 埋め込みサービス (Phase 4: ML リコメンド)
-    pub embedding_service: Option<Arc<EmbeddingService>>,
+    /// RwLock でラップして setup 時に初期化できるようにする
+    pub embedding_service: RwLock<Option<Arc<EmbeddingService>>>,
 }


### PR DESCRIPTION
Issues:
- Embedding service was not initialized correctly due to wrong resource path
- ONNX files (vision and text models) were not being bundled in release builds
- GitHub Actions workflow was not fetching Git LFS files

Changes:
1. Enable Git LFS in GitHub Actions workflow (.github/workflows/tauri_release.yml)
   - Add 'lfs: true' option to actions/checkout
   - Add explicit 'git lfs pull' step

2. Move embedding_service initialization to setup callback (src-tauri/src/app/mod.rs)
   - Use AppHandle::path().resource_dir() to correctly resolve bundled resource path
   - Add file size validation to detect corrupted/incomplete LFS files
   - Add debug logging to track initialization process

3. Wrap embedding_service in RwLock (src-tauri/src/service/types.rs)
   - Change from Option<Arc<EmbeddingService>> to RwLock<Option<Arc<EmbeddingService>>>
   - Allows lazy initialization in setup callback

4. Update embedding_service access in explorer.rs
   - Adapt to RwLock wrapper with async read operations

This ensures CLIP models are correctly bundled and the recommendation rebuild feature works properly on production builds.