### PR TITLE
perf: ブロッキング I/O を async コンテキスト外に移動し、冷え冷え OS キャッシュ時の全操作遅延を修正

### DIFF
--- a/src-tauri/src/app/explorer.rs
+++ b/src-tauri/src/app/explorer.rs
@@ -24,8 +24,13 @@ pub(crate) async fn transfer_folder(
     state: State<'_, AppState>,
     app: AppHandle,
 ) -> Result<(), String> {
-    let options = CopyOptions::new();
-    move_dir(from, to, &options).map_err(|e| format!("failed to move folder: {e}"))?;
+    // spawn_blocking でファイル移動（同期 I/O）を実行
+    tokio::task::spawn_blocking(move || {
+        let options = CopyOptions::new();
+        move_dir(from, to, &options).map_err(|e| format!("failed to move folder: {e}"))
+    })
+    .await
+    .map_err(|e| format!("Failed to spawn blocking task: {}", e))??;
 
     // フォルダ移動した結果の表示更新
     let (index, (path, mut page, sort, search_query)) =
@@ -41,7 +46,7 @@ pub(crate) async fn transfer_folder(
         state.dir_list_cache.clone(),
         &sort,
         search_query.as_deref(),
-        Some(&state.db),
+        Some(state.db.clone()),
     )
     .await?;
     if page > total_pages {
@@ -184,7 +189,7 @@ pub(crate) async fn change_explorer_path(
         state.dir_list_cache.clone(),
         &sort,
         search_query.as_deref(),
-        Some(&state.db),
+        Some(state.db.clone()),
     )
     .await?;
 
@@ -299,7 +304,7 @@ pub(crate) async fn change_explorer_page(
         state.dir_list_cache.clone(),
         &sort,
         search_query.as_deref(),
-        Some(&state.db),
+        Some(state.db.clone()),
     )
     .await?;
     let tab_state = update_tab_state(&label, index, page, thumbnails, total_pages, &state).await?;
@@ -336,7 +341,7 @@ pub(crate) async fn move_explorer_forward(
         state.dir_list_cache.clone(),
         &sort,
         search_query.as_deref(),
-        Some(&state.db),
+        Some(state.db.clone()),
     )
     .await?;
     if page > total_pages {
@@ -371,7 +376,7 @@ pub(crate) async fn move_explorer_backward(
         state.dir_list_cache.clone(),
         &sort,
         search_query.as_deref(),
-        Some(&state.db),
+        Some(state.db.clone()),
     )
     .await?;
     update_tab_and_emit(&label, index, page, thumbnails, total_pages, &state, &app).await?;
@@ -394,7 +399,7 @@ pub(crate) async fn move_explorer_to_end(
         state.dir_list_cache.clone(),
         &sort,
         search_query.as_deref(),
-        Some(&state.db),
+        Some(state.db.clone()),
     )
     .await?;
     let page = total_pages;
@@ -405,7 +410,7 @@ pub(crate) async fn move_explorer_to_end(
         state.dir_list_cache.clone(),
         &sort,
         search_query.as_deref(),
-        Some(&state.db),
+        Some(state.db.clone()),
     )
     .await?;
 
@@ -430,7 +435,7 @@ pub(crate) async fn move_explorer_to_start(
         state.dir_list_cache.clone(),
         &sort,
         search_query.as_deref(),
-        Some(&state.db),
+        Some(state.db.clone()),
     )
     .await?;
     update_tab_and_emit(&label, index, page, thumbnails, total_pages, &state, &app).await?;
@@ -487,7 +492,7 @@ pub(crate) async fn refresh_explorer_tab(
         state.dir_list_cache.clone(),
         &sort,
         search_query.as_deref(),
-        Some(&state.db),
+        Some(state.db.clone()),
     )
     .await?;
     update_tab_and_emit(&label, index, page, thumbnails, total_pages, &state, &app).await?;
@@ -528,7 +533,7 @@ pub(crate) async fn change_explorer_sort(
             state.dir_list_cache.clone(),
             &sort,
             search_query.as_deref(),
-            Some(&state.db),
+            Some(state.db.clone()),
         )
         .await?;
         update_tab_and_emit(&label, index, 1, thumbnails, total_pages, &state, &app).await?;
@@ -573,7 +578,7 @@ pub(crate) async fn change_explorer_search(
             state.dir_list_cache.clone(),
             &sort,
             query.as_deref(),
-            Some(&state.db),
+            Some(state.db.clone()),
         )
         .await?;
         update_tab_and_emit(&label, index, 1, thumbnails, total_pages, &state, &app).await?;

--- a/src-tauri/src/app/explorer.rs
+++ b/src-tauri/src/app/explorer.rs
@@ -4,13 +4,14 @@ use tauri::{AppHandle, Emitter, State, WebviewUrl, WebviewWindowBuilder};
 
 use crate::service::app_state::AppState;
 use crate::service::explorer_state::{
-    add_explorer_state, add_explorer_tab_state, explore_path_with_count,
-    get_active_tab_state_query, get_tab_index_by_key, get_tab_state_by_index,
-    get_tab_state_query_by_key, remove_explorer_tab_state, reset_explorer_tab_state,
-    update_tab_state, Thumbnail,
+    add_explorer_state, add_explorer_tab_state, clear_dir_list_cache_for_dir,
+    explore_path_with_count, get_active_tab_state_query, get_tab_index_by_key,
+    get_tab_state_by_index, get_tab_state_query_by_key, remove_explorer_tab_state,
+    reset_explorer_tab_state, update_tab_state, Thumbnail,
 };
 use crate::service::explorer_types::SortConfig;
 use crate::service::types::ActiveTab;
+use crate::utils::file_utils::find_first_image_in_folder;
 use crate::utils::watcher_utils::{
     create_explorer_watcher_callback, subscribe_directory, unsubscribe_directory,
 };
@@ -24,16 +25,20 @@ pub(crate) async fn transfer_folder(
     app: AppHandle,
 ) -> Result<(), String> {
     let options = CopyOptions::new();
-    move_dir(from, to, &options).map_err(|_| "failed to move folder")?;
+    move_dir(from, to, &options).map_err(|e| format!("failed to move folder: {e}"))?;
 
     // フォルダ移動した結果の表示更新
     let (index, (path, mut page, sort, search_query)) =
         get_active_tab_state_query(&label, &state, |p| p).await?;
 
+    // フォルダが移動されたのでキャッシュを無効化
+    clear_dir_list_cache_for_dir(&path, state.dir_list_cache.clone()).await;
+
     let (thumbnails, total_pages) = explore_path_with_count(
         &path,
         page,
         state.thumbnail_cache.clone(),
+        state.dir_list_cache.clone(),
         &sort,
         search_query.as_deref(),
         Some(&state.db),
@@ -112,12 +117,14 @@ pub(crate) async fn request_restore_explorer_state<'a>(
     state: State<'a, AppState>,
     app: AppHandle,
 ) -> Result<(), String> {
-    let mut explorers = state.explorers.lock().await;
+    let explorers = state.explorers.lock().await;
     let explorer_state = (*explorers)
-        .iter_mut()
+        .iter()
         .find(|w| w.label == label)
         .ok_or_else(|| "explorer not found".to_string())?;
-    app.emit_to(&label, "explorer-state-changed", explorer_state.clone())
+    let cloned = explorer_state.clone();
+    drop(explorers);
+    app.emit_to(&label, "explorer-state-changed", &cloned)
         .map_err(|_| "failed to emit explorer state".to_string())?;
     Ok(())
 }
@@ -129,17 +136,19 @@ pub(crate) async fn request_restore_explorer_tab_state<'a>(
     state: State<'a, AppState>,
     app: AppHandle,
 ) -> Result<(), String> {
-    let mut explorers = state.explorers.lock().await;
+    let explorers = state.explorers.lock().await;
     let explorer_state = (*explorers)
-        .iter_mut()
+        .iter()
         .find(|w| w.label == label)
         .ok_or_else(|| "explorer not found".to_string())?;
     let tab_state = explorer_state
         .tabs
-        .iter_mut()
+        .iter()
         .find(|t| t.key == key)
-        .ok_or_else(|| "tab not found".to_string())?;
-    app.emit_to(&label, "explorer-tab-state-changed", tab_state.clone())
+        .ok_or_else(|| "tab not found".to_string())?
+        .clone();
+    drop(explorers);
+    app.emit_to(&label, "explorer-tab-state-changed", &tab_state)
         .map_err(|_| "failed to emit explorer state".to_string())?;
     Ok(())
 }
@@ -172,6 +181,7 @@ pub(crate) async fn change_explorer_path(
         &path,
         1,
         state.thumbnail_cache.clone(),
+        state.dir_list_cache.clone(),
         &sort,
         search_query.as_deref(),
         Some(&state.db),
@@ -286,6 +296,7 @@ pub(crate) async fn change_explorer_page(
         &path,
         page,
         state.thumbnail_cache.clone(),
+        state.dir_list_cache.clone(),
         &sort,
         search_query.as_deref(),
         Some(&state.db),
@@ -322,6 +333,7 @@ pub(crate) async fn move_explorer_forward(
         &path,
         page,
         state.thumbnail_cache.clone(),
+        state.dir_list_cache.clone(),
         &sort,
         search_query.as_deref(),
         Some(&state.db),
@@ -356,6 +368,7 @@ pub(crate) async fn move_explorer_backward(
         &path,
         page,
         state.thumbnail_cache.clone(),
+        state.dir_list_cache.clone(),
         &sort,
         search_query.as_deref(),
         Some(&state.db),
@@ -378,6 +391,7 @@ pub(crate) async fn move_explorer_to_end(
         &path,
         1,
         state.thumbnail_cache.clone(),
+        state.dir_list_cache.clone(),
         &sort,
         search_query.as_deref(),
         Some(&state.db),
@@ -388,6 +402,7 @@ pub(crate) async fn move_explorer_to_end(
         &path,
         page,
         state.thumbnail_cache.clone(),
+        state.dir_list_cache.clone(),
         &sort,
         search_query.as_deref(),
         Some(&state.db),
@@ -412,6 +427,7 @@ pub(crate) async fn move_explorer_to_start(
         &path,
         page,
         state.thumbnail_cache.clone(),
+        state.dir_list_cache.clone(),
         &sort,
         search_query.as_deref(),
         Some(&state.db),
@@ -429,8 +445,12 @@ pub(crate) async fn subscribe_explorer_dir_notification(
     state: State<'_, AppState>,
     app: AppHandle,
 ) -> Result<(), String> {
-    let callback =
-        create_explorer_watcher_callback(app, dir_path.clone(), state.thumbnail_cache.clone());
+    let callback = create_explorer_watcher_callback(
+        app,
+        dir_path.clone(),
+        state.thumbnail_cache.clone(),
+        state.dir_list_cache.clone(),
+    );
 
     subscribe_directory(dir_path, &state, RecursiveMode::NonRecursive, callback).await
 }
@@ -457,10 +477,14 @@ pub(crate) async fn refresh_explorer_tab(
     let (index, (path, page, sort, search_query)) =
         get_tab_state_query_by_key(&label, &key, &state).await?;
 
+    // watcher コールバックと refresh コマンドの到着順が不定なためキャッシュを先にクリアする
+    clear_dir_list_cache_for_dir(&path, state.dir_list_cache.clone()).await;
+
     let (thumbnails, total_pages) = explore_path_with_count(
         &path,
         page,
         state.thumbnail_cache.clone(),
+        state.dir_list_cache.clone(),
         &sort,
         search_query.as_deref(),
         Some(&state.db),
@@ -495,10 +519,13 @@ pub(crate) async fn change_explorer_sort(
 
     // パスがない場合（デバイス一覧）はソートしない
     if let Some(path) = path {
+        // ソート条件が変わるため古いキャッシュエントリを破棄する
+        clear_dir_list_cache_for_dir(&path, state.dir_list_cache.clone()).await;
         let (thumbnails, total_pages) = explore_path_with_count(
             &path,
             1,
             state.thumbnail_cache.clone(),
+            state.dir_list_cache.clone(),
             &sort,
             search_query.as_deref(),
             Some(&state.db),
@@ -537,10 +564,13 @@ pub(crate) async fn change_explorer_search(
 
     // パスがない場合（デバイス一覧）は検索しない
     if let Some(path) = path {
+        // 検索条件が変わるため古いキャッシュエントリを破棄する
+        clear_dir_list_cache_for_dir(&path, state.dir_list_cache.clone()).await;
         let (thumbnails, total_pages) = explore_path_with_count(
             &path,
             1,
             state.thumbnail_cache.clone(),
+            state.dir_list_cache.clone(),
             &sort,
             query.as_deref(),
             Some(&state.db),
@@ -781,30 +811,6 @@ pub(crate) async fn rebuild_recommendations(
     });
 
     Ok(())
-}
-
-/// フォルダの最初の画像ファイルを見つける
-fn find_first_image_in_folder(folder_path: &std::path::Path) -> String {
-    use std::fs::read_dir;
-
-    let extensions = [
-        "jpg", "jpeg", "JPG", "JPEG", "jpe", "jfif", "pjpeg", "pjp", "png", "PNG", "gif", "tif",
-        "tiff", "bmp", "dib", "webp",
-    ];
-
-    if let Ok(inner_file) = read_dir(folder_path) {
-        for entry in inner_file.flatten() {
-            let path = entry.path();
-            let ext = path
-                .extension()
-                .and_then(|e| e.to_str())
-                .unwrap_or_default();
-            if extensions.contains(&ext) {
-                return path.to_str().unwrap_or_default().to_string();
-            }
-        }
-    }
-    String::new()
 }
 
 /// リコメンド再構築が処理中かどうかを取得

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -118,6 +118,9 @@ pub fn create_viewer() -> Builder<Wry> {
         thumbnail_cache: std::sync::Arc::new(tokio::sync::RwLock::new(
             std::collections::HashMap::new(),
         )),
+        dir_list_cache: std::sync::Arc::new(tokio::sync::RwLock::new(
+            std::collections::HashMap::new(),
+        )),
         db: std::sync::Arc::new(db),
         embedding_service: tokio::sync::RwLock::new(None),
     };

--- a/src-tauri/src/app/viewer.rs
+++ b/src-tauri/src/app/viewer.rs
@@ -74,6 +74,39 @@ pub(crate) async fn refresh_viewer_tab_tree(
     state: State<'_, AppState>,
     app: AppHandle,
 ) -> Result<(), String> {
+    // ロックを短時間だけ保持して必要な情報を取得する
+    let (path, is_compressed, current_key) = {
+        let viewers = state.viewers.lock().await;
+        let viewer_state = (*viewers)
+            .iter()
+            .find(|w| w.label == label)
+            .ok_or_else(|| "viewer not found".to_string())?;
+        let tab_state = viewer_state
+            .tabs
+            .iter()
+            .find(|t| t.key == tab_key)
+            .ok_or_else(|| "tab not found".to_string())?;
+        let is_compressed = tab_state
+            .viewing
+            .as_ref()
+            .map(|v| v.file_type == "Zip")
+            .unwrap_or(false);
+        let current_key = tab_state.viewing.as_ref().map(|v| v.key.clone());
+        (tab_state.path.clone(), is_compressed, current_key)
+    }; // ロック解放
+
+    // ファイルツリー再構築をロック外のブロッキングスレッドで実行
+    let new_tree = tokio::task::spawn_blocking(move || rebuild_file_tree(&path, is_compressed))
+        .await
+        .map_err(|e| format!("Failed to rebuild file tree: {}", e))?;
+
+    let new_viewing = if let Some(key) = current_key {
+        find_key_in_tree(&new_tree, &key)
+    } else {
+        None
+    };
+
+    // ロックを再取得して状態を更新する
     let mut viewers = state.viewers.lock().await;
     let viewer_state = (*viewers)
         .iter_mut()
@@ -84,24 +117,6 @@ pub(crate) async fn refresh_viewer_tab_tree(
         .iter_mut()
         .find(|t| t.key == tab_key)
         .ok_or_else(|| "tab not found".to_string())?;
-
-    // ZIPファイルかどうかを判定（viewing.file_typeで判断）
-    let is_compressed = tab_state
-        .viewing
-        .as_ref()
-        .map(|v| v.file_type == "Zip")
-        .unwrap_or(false);
-
-    // ファイルツリーを再構築
-    let new_tree = rebuild_file_tree(&tab_state.path, is_compressed);
-
-    // 現在表示中のファイルがまだ存在するか確認
-    let current_key = tab_state.viewing.as_ref().map(|v| v.key.clone());
-    let new_viewing = if let Some(key) = current_key {
-        find_key_in_tree(&new_tree, &key)
-    } else {
-        None
-    };
 
     tab_state.tree = new_tree;
     tab_state.viewing = new_viewing;

--- a/src-tauri/src/service/explorer_state.rs
+++ b/src-tauri/src/service/explorer_state.rs
@@ -2,7 +2,6 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fs::read_dir;
 use std::sync::Arc;
 use sysinfo::Disks;
 use tauri::State;
@@ -434,6 +433,106 @@ fn calculate_recommendation_scores(db: &Database, folder_paths: &[String]) -> Ha
     scores
 }
 
+/// ディレクトリをスキャン・ソートし、CachedDirEntry 一覧を返す（同期関数、spawn_blocking から呼ぶ）
+fn scan_and_sort_dirs_sync(
+    filepath: &str,
+    sort: &SortConfig,
+    search_query: Option<&str>,
+    db: Option<&Database>,
+) -> Result<Vec<CachedDirEntry>, String> {
+    use std::time::UNIX_EPOCH;
+
+    let dirs = std::fs::read_dir(filepath).map_err(|_| "failed to open path")?;
+    let mut entries: Vec<_> = dirs
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .collect();
+
+    // 検索フィルタリング
+    if let Some(query) = search_query {
+        if !query.is_empty() {
+            let query_lower = query.to_lowercase();
+            entries.retain(|e| {
+                e.file_name()
+                    .to_str()
+                    .map(|name| name.to_lowercase().contains(&query_lower))
+                    .unwrap_or(false)
+            });
+        }
+    }
+
+    // メタデータ取得
+    let mut entries_with_meta: Vec<_> = entries
+        .into_iter()
+        .map(|e| {
+            let metadata = e.metadata().ok();
+            let modified = metadata
+                .as_ref()
+                .and_then(|m| m.modified().ok())
+                .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                .map(|d| d.as_secs());
+            let created = metadata
+                .as_ref()
+                .and_then(|m| m.created().ok())
+                .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                .map(|d| d.as_secs());
+            (e, modified, created)
+        })
+        .collect();
+
+    // ソート実行
+    match (&sort.field, &sort.order) {
+        (SortField::Name, SortOrder::Asc) => {
+            entries_with_meta.sort_by(|a, b| a.0.file_name().cmp(&b.0.file_name()));
+        }
+        (SortField::Name, SortOrder::Desc) => {
+            entries_with_meta.sort_by(|a, b| b.0.file_name().cmp(&a.0.file_name()));
+        }
+        (SortField::DateModified, SortOrder::Asc) => {
+            entries_with_meta.sort_by(|a, b| a.1.cmp(&b.1));
+        }
+        (SortField::DateModified, SortOrder::Desc) => {
+            entries_with_meta.sort_by(|a, b| b.1.cmp(&a.1));
+        }
+        (SortField::DateCreated, SortOrder::Asc) => {
+            entries_with_meta.sort_by(|a, b| a.2.cmp(&b.2));
+        }
+        (SortField::DateCreated, SortOrder::Desc) => {
+            entries_with_meta.sort_by(|a, b| b.2.cmp(&a.2));
+        }
+        (SortField::Recommendation, _) => {
+            if let Some(db) = db {
+                let folder_paths: Vec<String> = entries_with_meta
+                    .iter()
+                    .map(|(e, _, _)| e.path().to_str().unwrap_or_default().to_string())
+                    .collect();
+                let scores = calculate_recommendation_scores(db, &folder_paths);
+                entries_with_meta.sort_by(|a, b| {
+                    let path_a = a.0.path().to_str().unwrap_or_default().to_string();
+                    let path_b = b.0.path().to_str().unwrap_or_default().to_string();
+                    let score_a = scores.get(&path_a).unwrap_or(&0.0);
+                    let score_b = scores.get(&path_b).unwrap_or(&0.0);
+                    score_b
+                        .partial_cmp(score_a)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+            } else {
+                entries_with_meta.sort_by(|a, b| b.1.cmp(&a.1));
+            }
+        }
+    }
+
+    Ok(entries_with_meta
+        .into_iter()
+        .map(|(e, modified, created)| CachedDirEntry {
+            path: e.path().to_str().unwrap_or_default().to_string(),
+            filename: e.file_name().to_str().unwrap_or_default().to_string(),
+            modified_at: modified,
+            created_at: created,
+        })
+        .collect())
+}
+
 /// ディレクトリスキャン、ソート、ページネーション、サムネイル抽出を統合した最適化版
 /// dir_list_cache を利用して同一条件の再スキャンを省略する
 pub(crate) async fn explore_path_with_count(
@@ -443,10 +542,8 @@ pub(crate) async fn explore_path_with_count(
     dir_list_cache: Arc<RwLock<HashMap<String, Vec<CachedDirEntry>>>>,
     sort: &SortConfig,
     search_query: Option<&str>,
-    db: Option<&Database>,
+    db: Option<Arc<Database>>,
 ) -> Result<(Vec<Thumbnail>, usize), String> {
-    use std::time::UNIX_EPOCH;
-
     let cache_key = make_dir_list_cache_key(filepath, sort, search_query);
 
     // 1. ディレクトリリストキャッシュをチェック
@@ -458,98 +555,22 @@ pub(crate) async fn explore_path_with_count(
     let all_entries: Vec<CachedDirEntry> = if let Some(entries) = cached {
         entries
     } else {
-        // キャッシュミス: ディレクトリスキャン実行
-        let dirs = read_dir(filepath).map_err(|_| "failed to open path")?;
-        let mut entries: Vec<_> = dirs
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().is_dir())
-            .collect();
+        // キャッシュミス: spawn_blocking でブロッキング I/O を非同期コンテキスト外で実行
+        let filepath_owned = filepath.to_string();
+        let sort_clone = sort.clone();
+        let search_owned = search_query.map(String::from);
+        let db_clone = db.clone();
 
-        // 検索フィルタリング
-        if let Some(query) = search_query {
-            if !query.is_empty() {
-                let query_lower = query.to_lowercase();
-                entries.retain(|e| {
-                    e.file_name()
-                        .to_str()
-                        .map(|name| name.to_lowercase().contains(&query_lower))
-                        .unwrap_or(false)
-                });
-            }
-        }
-
-        // メタデータ取得してソート
-        let mut entries_with_meta: Vec<_> = entries
-            .into_iter()
-            .map(|e| {
-                let metadata = e.metadata().ok();
-                let modified = metadata
-                    .as_ref()
-                    .and_then(|m| m.modified().ok())
-                    .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-                    .map(|d| d.as_secs());
-                let created = metadata
-                    .as_ref()
-                    .and_then(|m| m.created().ok())
-                    .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-                    .map(|d| d.as_secs());
-                (e, modified, created)
-            })
-            .collect();
-
-        // ソート実行
-        match (&sort.field, &sort.order) {
-            (SortField::Name, SortOrder::Asc) => {
-                entries_with_meta.sort_by(|a, b| a.0.file_name().cmp(&b.0.file_name()));
-            }
-            (SortField::Name, SortOrder::Desc) => {
-                entries_with_meta.sort_by(|a, b| b.0.file_name().cmp(&a.0.file_name()));
-            }
-            (SortField::DateModified, SortOrder::Asc) => {
-                entries_with_meta.sort_by(|a, b| a.1.cmp(&b.1));
-            }
-            (SortField::DateModified, SortOrder::Desc) => {
-                entries_with_meta.sort_by(|a, b| b.1.cmp(&a.1));
-            }
-            (SortField::DateCreated, SortOrder::Asc) => {
-                entries_with_meta.sort_by(|a, b| a.2.cmp(&b.2));
-            }
-            (SortField::DateCreated, SortOrder::Desc) => {
-                entries_with_meta.sort_by(|a, b| b.2.cmp(&a.2));
-            }
-            // リコメンドソート: DBから埋め込みスコアを計算してソート
-            (SortField::Recommendation, _) => {
-                if let Some(db) = db {
-                    let folder_paths: Vec<String> = entries_with_meta
-                        .iter()
-                        .map(|(e, _, _)| e.path().to_str().unwrap_or_default().to_string())
-                        .collect();
-                    let scores = calculate_recommendation_scores(db, &folder_paths);
-                    entries_with_meta.sort_by(|a, b| {
-                        let path_a = a.0.path().to_str().unwrap_or_default().to_string();
-                        let path_b = b.0.path().to_str().unwrap_or_default().to_string();
-                        let score_a = scores.get(&path_a).unwrap_or(&0.0);
-                        let score_b = scores.get(&path_b).unwrap_or(&0.0);
-                        score_b
-                            .partial_cmp(score_a)
-                            .unwrap_or(std::cmp::Ordering::Equal)
-                    });
-                } else {
-                    entries_with_meta.sort_by(|a, b| b.1.cmp(&a.1));
-                }
-            }
-        }
-
-        // CachedDirEntry に変換してキャッシュへ保存
-        let new_entries: Vec<CachedDirEntry> = entries_with_meta
-            .into_iter()
-            .map(|(e, modified, created)| CachedDirEntry {
-                path: e.path().to_str().unwrap_or_default().to_string(),
-                filename: e.file_name().to_str().unwrap_or_default().to_string(),
-                modified_at: modified,
-                created_at: created,
-            })
-            .collect();
+        let new_entries = tokio::task::spawn_blocking(move || {
+            scan_and_sort_dirs_sync(
+                &filepath_owned,
+                &sort_clone,
+                search_owned.as_deref(),
+                db_clone.as_deref(),
+            )
+        })
+        .await
+        .map_err(|e| format!("Failed to scan directory: {}", e))??;
 
         {
             let mut w = dir_list_cache.write().await;

--- a/src-tauri/src/service/explorer_state.rs
+++ b/src-tauri/src/service/explorer_state.rs
@@ -8,6 +8,8 @@ use sysinfo::Disks;
 use tauri::State;
 use tokio::sync::RwLock;
 
+use crate::utils::file_utils::find_first_image_in_folder;
+
 use crate::service::database::Database;
 use crate::service::embedding_service::{
     average_embeddings, cosine_similarity, embedding_from_bytes,
@@ -19,6 +21,15 @@ use super::types::{ActiveTab, AppState};
 // ========================================
 // 型定義
 // ========================================
+
+/// ディレクトリリストキャッシュ用エントリ（シリアライズ不要な軽量型）
+#[derive(Debug, Clone)]
+pub struct CachedDirEntry {
+    pub path: String,
+    pub filename: String,
+    pub modified_at: Option<u64>,
+    pub created_at: Option<u64>,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Thumbnail {
@@ -58,14 +69,18 @@ pub struct ExplorerState {
 
 pub(crate) async fn add_explorer_state<'a>(state: &State<'a, AppState>) -> Result<String, String> {
     let mut explorers = state.explorers.lock().await;
-    let label = format!("explorer-{}", *state.count.lock().await);
+    let label = {
+        let mut count = state.count.lock().await;
+        let l = format!("explorer-{}", *count);
+        *count += 1;
+        l
+    };
     (*explorers).push(ExplorerState {
         label: label.clone(),
         count: 0,
         active: None,
         tabs: vec![],
     });
-    *state.count.lock().await += 1;
     Ok(label)
 }
 
@@ -298,26 +313,19 @@ pub(crate) async fn update_tab_state(
 
 const CATALOG_PER_PAGE: usize = 50;
 
-/// 最初の画像ファイルを見つける (キャッシュなしの場合の処理)
-fn find_first_image_in_folder(folder_path: &std::path::Path) -> String {
-    let extensions = vec![
-        "jpg", "jpeg", "JPG", "JPEG", "jpe", "jfif", "pjpeg", "pjp", "png", "PNG", "gif", "tif",
-        "tiff", "bmp", "dib", "webp",
-    ];
-
-    if let Ok(inner_file) = read_dir(folder_path) {
-        for entry in inner_file.flatten() {
-            let path = entry.path();
-            let ext = path
-                .extension()
-                .and_then(|e| e.to_str())
-                .unwrap_or_default();
-            if extensions.contains(&ext) {
-                return path.to_str().unwrap_or_default().to_string();
-            }
-        }
-    }
-    String::new()
+/// ディレクトリリストキャッシュのキーを生成する
+fn make_dir_list_cache_key(
+    filepath: &str,
+    sort: &SortConfig,
+    search_query: Option<&str>,
+) -> String {
+    format!(
+        "{}|{:?}:{:?}|{}",
+        filepath,
+        sort.field,
+        sort.order,
+        search_query.unwrap_or("")
+    )
 }
 
 /// リコメンドスコアを計算
@@ -427,113 +435,139 @@ fn calculate_recommendation_scores(db: &Database, folder_paths: &[String]) -> Ha
 }
 
 /// ディレクトリスキャン、ソート、ページネーション、サムネイル抽出を統合した最適化版
+/// dir_list_cache を利用して同一条件の再スキャンを省略する
 pub(crate) async fn explore_path_with_count(
     filepath: &str,
     page: usize,
     cache: Arc<RwLock<HashMap<String, String>>>,
+    dir_list_cache: Arc<RwLock<HashMap<String, Vec<CachedDirEntry>>>>,
     sort: &SortConfig,
     search_query: Option<&str>,
     db: Option<&Database>,
 ) -> Result<(Vec<Thumbnail>, usize), String> {
     use std::time::UNIX_EPOCH;
 
-    // 1. 単一スキャンで全エントリを収集
-    let dirs = read_dir(filepath).map_err(|_| "failed to open path")?;
-    let mut entries: Vec<_> = dirs
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().is_dir())
-        .collect();
+    let cache_key = make_dir_list_cache_key(filepath, sort, search_query);
 
-    // 2. 検索フィルタリング
-    if let Some(query) = search_query {
-        if !query.is_empty() {
-            let query_lower = query.to_lowercase();
-            entries.retain(|e| {
-                e.file_name()
-                    .to_str()
-                    .map(|name| name.to_lowercase().contains(&query_lower))
-                    .unwrap_or(false)
-            });
-        }
-    }
+    // 1. ディレクトリリストキャッシュをチェック
+    let cached = {
+        let r = dir_list_cache.read().await;
+        r.get(&cache_key).cloned()
+    };
 
-    // 3. メタデータ取得してソート
-    let mut entries_with_meta: Vec<_> = entries
-        .into_iter()
-        .map(|e| {
-            let metadata = e.metadata().ok();
-            let modified = metadata
-                .as_ref()
-                .and_then(|m| m.modified().ok())
-                .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-                .map(|d| d.as_secs());
-            let created = metadata
-                .as_ref()
-                .and_then(|m| m.created().ok())
-                .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-                .map(|d| d.as_secs());
-            (e, modified, created)
-        })
-        .collect();
+    let all_entries: Vec<CachedDirEntry> = if let Some(entries) = cached {
+        entries
+    } else {
+        // キャッシュミス: ディレクトリスキャン実行
+        let dirs = read_dir(filepath).map_err(|_| "failed to open path")?;
+        let mut entries: Vec<_> = dirs
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
 
-    // ソート実行
-    match (&sort.field, &sort.order) {
-        (SortField::Name, SortOrder::Asc) => {
-            entries_with_meta.sort_by(|a, b| a.0.file_name().cmp(&b.0.file_name()));
-        }
-        (SortField::Name, SortOrder::Desc) => {
-            entries_with_meta.sort_by(|a, b| b.0.file_name().cmp(&a.0.file_name()));
-        }
-        (SortField::DateModified, SortOrder::Asc) => {
-            entries_with_meta.sort_by(|a, b| a.1.cmp(&b.1));
-        }
-        (SortField::DateModified, SortOrder::Desc) => {
-            entries_with_meta.sort_by(|a, b| b.1.cmp(&a.1));
-        }
-        (SortField::DateCreated, SortOrder::Asc) => {
-            entries_with_meta.sort_by(|a, b| a.2.cmp(&b.2));
-        }
-        (SortField::DateCreated, SortOrder::Desc) => {
-            entries_with_meta.sort_by(|a, b| b.2.cmp(&a.2));
-        }
-        // リコメンドソート: DBから埋め込みスコアを計算してソート
-        (SortField::Recommendation, _) => {
-            if let Some(db) = db {
-                // フォルダパスのリストを取得
-                let folder_paths: Vec<String> = entries_with_meta
-                    .iter()
-                    .map(|(e, _, _)| e.path().to_str().unwrap_or_default().to_string())
-                    .collect();
-
-                // スコアを計算
-                let scores = calculate_recommendation_scores(db, &folder_paths);
-
-                // スコアでソート（降順）
-                entries_with_meta.sort_by(|a, b| {
-                    let path_a = a.0.path().to_str().unwrap_or_default().to_string();
-                    let path_b = b.0.path().to_str().unwrap_or_default().to_string();
-                    let score_a = scores.get(&path_a).unwrap_or(&0.0);
-                    let score_b = scores.get(&path_b).unwrap_or(&0.0);
-                    score_b
-                        .partial_cmp(score_a)
-                        .unwrap_or(std::cmp::Ordering::Equal)
+        // 検索フィルタリング
+        if let Some(query) = search_query {
+            if !query.is_empty() {
+                let query_lower = query.to_lowercase();
+                entries.retain(|e| {
+                    e.file_name()
+                        .to_str()
+                        .map(|name| name.to_lowercase().contains(&query_lower))
+                        .unwrap_or(false)
                 });
-            } else {
-                // DBがない場合は更新日時降順でフォールバック
-                entries_with_meta.sort_by(|a, b| b.1.cmp(&a.1));
             }
         }
-    }
 
-    // 4. 総ページ数を計算
-    let total_count = entries_with_meta.len();
+        // メタデータ取得してソート
+        let mut entries_with_meta: Vec<_> = entries
+            .into_iter()
+            .map(|e| {
+                let metadata = e.metadata().ok();
+                let modified = metadata
+                    .as_ref()
+                    .and_then(|m| m.modified().ok())
+                    .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                    .map(|d| d.as_secs());
+                let created = metadata
+                    .as_ref()
+                    .and_then(|m| m.created().ok())
+                    .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                    .map(|d| d.as_secs());
+                (e, modified, created)
+            })
+            .collect();
+
+        // ソート実行
+        match (&sort.field, &sort.order) {
+            (SortField::Name, SortOrder::Asc) => {
+                entries_with_meta.sort_by(|a, b| a.0.file_name().cmp(&b.0.file_name()));
+            }
+            (SortField::Name, SortOrder::Desc) => {
+                entries_with_meta.sort_by(|a, b| b.0.file_name().cmp(&a.0.file_name()));
+            }
+            (SortField::DateModified, SortOrder::Asc) => {
+                entries_with_meta.sort_by(|a, b| a.1.cmp(&b.1));
+            }
+            (SortField::DateModified, SortOrder::Desc) => {
+                entries_with_meta.sort_by(|a, b| b.1.cmp(&a.1));
+            }
+            (SortField::DateCreated, SortOrder::Asc) => {
+                entries_with_meta.sort_by(|a, b| a.2.cmp(&b.2));
+            }
+            (SortField::DateCreated, SortOrder::Desc) => {
+                entries_with_meta.sort_by(|a, b| b.2.cmp(&a.2));
+            }
+            // リコメンドソート: DBから埋め込みスコアを計算してソート
+            (SortField::Recommendation, _) => {
+                if let Some(db) = db {
+                    let folder_paths: Vec<String> = entries_with_meta
+                        .iter()
+                        .map(|(e, _, _)| e.path().to_str().unwrap_or_default().to_string())
+                        .collect();
+                    let scores = calculate_recommendation_scores(db, &folder_paths);
+                    entries_with_meta.sort_by(|a, b| {
+                        let path_a = a.0.path().to_str().unwrap_or_default().to_string();
+                        let path_b = b.0.path().to_str().unwrap_or_default().to_string();
+                        let score_a = scores.get(&path_a).unwrap_or(&0.0);
+                        let score_b = scores.get(&path_b).unwrap_or(&0.0);
+                        score_b
+                            .partial_cmp(score_a)
+                            .unwrap_or(std::cmp::Ordering::Equal)
+                    });
+                } else {
+                    entries_with_meta.sort_by(|a, b| b.1.cmp(&a.1));
+                }
+            }
+        }
+
+        // CachedDirEntry に変換してキャッシュへ保存
+        let new_entries: Vec<CachedDirEntry> = entries_with_meta
+            .into_iter()
+            .map(|(e, modified, created)| CachedDirEntry {
+                path: e.path().to_str().unwrap_or_default().to_string(),
+                filename: e.file_name().to_str().unwrap_or_default().to_string(),
+                modified_at: modified,
+                created_at: created,
+            })
+            .collect();
+
+        {
+            let mut w = dir_list_cache.write().await;
+            w.insert(cache_key, new_entries.clone());
+        }
+
+        new_entries
+    };
+
+    // 2. 総ページ数を計算
+    let total_count = all_entries.len();
     let total_pages = if total_count == 0 {
         1
     } else {
         total_count.div_ceil(CATALOG_PER_PAGE)
     };
 
-    // 5. ページネーション
+    // 3. ページネーション
     let start = (page.saturating_sub(1)) * CATALOG_PER_PAGE;
     let end = (start + CATALOG_PER_PAGE).min(total_count);
 
@@ -541,21 +575,20 @@ pub(crate) async fn explore_path_with_count(
         return Ok((vec![], total_pages));
     }
 
-    let page_entries = &entries_with_meta[start..end];
+    let page_entries = &all_entries[start..end];
 
-    // 6. サムネイル抽出 (並列処理)
+    // 4. サムネイル抽出 (並列処理)
     let tasks: Vec<_> = page_entries
         .iter()
-        .map(|(entry, modified, created)| {
-            let path = entry.path();
-            let filename = entry.file_name().to_str().unwrap_or_default().to_string();
+        .map(|entry| {
+            let path_str = entry.path.clone();
+            let filename = entry.filename.clone();
+            let path_buf = std::path::PathBuf::from(&entry.path);
             let cache = cache.clone();
-            let modified = *modified;
-            let created = *created;
+            let modified = entry.modified_at;
+            let created = entry.created_at;
 
             tokio::spawn(async move {
-                let path_str = path.to_str().unwrap_or_default().to_string();
-
                 // キャッシュチェック
                 {
                     let cache_read = cache.read().await;
@@ -571,9 +604,8 @@ pub(crate) async fn explore_path_with_count(
                 }
 
                 // キャッシュミス: ブロッキングI/Oで検索
-                let path_clone = path.clone();
                 let thumb =
-                    tokio::task::spawn_blocking(move || find_first_image_in_folder(&path_clone))
+                    tokio::task::spawn_blocking(move || find_first_image_in_folder(&path_buf))
                         .await
                         .unwrap_or_default();
 
@@ -630,4 +662,15 @@ pub(crate) async fn clear_thumbnail_cache_for_dir(
 ) {
     let mut cache_write = cache.write().await;
     cache_write.retain(|k, _| !k.starts_with(dir_path));
+}
+
+/// 指定されたディレクトリのディレクトリリストキャッシュをクリア
+/// dir_path で始まるキャッシュエントリを全て削除する
+pub(crate) async fn clear_dir_list_cache_for_dir(
+    dir_path: &str,
+    cache: Arc<RwLock<HashMap<String, Vec<CachedDirEntry>>>>,
+) {
+    let prefix = format!("{}|", dir_path);
+    let mut cache_write = cache.write().await;
+    cache_write.retain(|k, _| !k.starts_with(&prefix));
 }

--- a/src-tauri/src/service/types.rs
+++ b/src-tauri/src/service/types.rs
@@ -8,7 +8,7 @@ use tokio::sync::{Mutex, RwLock};
 
 use super::database::Database;
 use super::embedding_service::EmbeddingService;
-use super::explorer_state::ExplorerState;
+use super::explorer_state::{CachedDirEntry, ExplorerState};
 use super::viewer_state::ViewerState;
 
 // ========================================
@@ -38,6 +38,9 @@ pub struct AppState {
     pub watchers: Mutex<HashMap<String, (RecommendedWatcher, usize)>>,
     /// サムネイルキャッシュ (folder_path -> thumbnail_path)
     pub thumbnail_cache: Arc<RwLock<HashMap<String, String>>>,
+    /// ディレクトリ一覧キャッシュ (cache_key -> ソート済みエントリ一覧)
+    /// cache_key = "{dir_path}|{sort_field:sort_order}|{search_query}"
+    pub dir_list_cache: Arc<RwLock<HashMap<String, Vec<CachedDirEntry>>>>,
     /// SQLite データベース (Phase 2: リコメンド基盤)
     pub db: Arc<Database>,
     /// CLIP 埋め込みサービス (Phase 4: ML リコメンド)

--- a/src-tauri/src/service/viewer_state.rs
+++ b/src-tauri/src/service/viewer_state.rs
@@ -86,34 +86,48 @@ pub(crate) async fn add_viewer_tab_state<'a>(
     label: &String,
     state: &State<'a, AppState>,
 ) -> Result<ViewerState, String> {
-    let mut viewers = state.viewers.lock().await;
-    let viewer_state = (*viewers)
-        .iter_mut()
-        .find(|w| w.label == *label)
-        .ok_or_else(|| "viewer not found".to_string())?;
-    viewer_state.count += 1;
-    let key = format!("tab-{}", viewer_state.count);
+    let is_compressed = is_compressed_file(path);
     let title = if is_executable_file(path) {
         get_parent_dir_name(path)
     } else {
         get_filename_without_extension(path)
     };
-    let new_path = if is_compressed_file(path) {
+    let new_path = if is_compressed {
         path.clone()
     } else {
         get_parent_dir(path)
     };
-    let tree = if is_compressed_file(path) {
-        get_compressed_file_tree(&new_path)
-    } else {
-        let mut key_count = 0;
-        get_file_tree(&new_path, &mut key_count)
+
+    // ロックを短時間だけ保持してタブキーを生成する
+    let key = {
+        let mut viewers = state.viewers.lock().await;
+        let viewer_state = (*viewers)
+            .iter_mut()
+            .find(|w| w.label == *label)
+            .ok_or_else(|| "viewer not found".to_string())?;
+        viewer_state.count += 1;
+        format!("tab-{}", viewer_state.count)
     };
-    let viewing = if is_compressed_file(path) {
+
+    // ファイルツリー構築をロック外のブロッキングスレッドで実行（同期 I/O がロックを長期保持しないよう分離）
+    let new_path_clone = new_path.clone();
+    let tree = tokio::task::spawn_blocking(move || {
+        if is_compressed {
+            get_compressed_file_tree(&new_path_clone)
+        } else {
+            let mut key_count = 0;
+            get_file_tree(&new_path_clone, &mut key_count)
+        }
+    })
+    .await
+    .map_err(|e| format!("Failed to build file tree: {}", e))?;
+
+    let viewing = if is_compressed {
         find_first_file(&tree)
     } else {
         find_path_in_tree(&tree, path)
     };
+
     let tab = ViewerTabState {
         title,
         key: key.clone(),
@@ -121,8 +135,15 @@ pub(crate) async fn add_viewer_tab_state<'a>(
         viewing,
         tree,
     };
-    viewer_state.tabs.push(tab.clone());
-    viewer_state.active = Some(ActiveTab { key: key.clone() });
+
+    // ロックを再取得してタブを追加する
+    let mut viewers = state.viewers.lock().await;
+    let viewer_state = (*viewers)
+        .iter_mut()
+        .find(|w| w.label == *label)
+        .ok_or_else(|| "viewer not found".to_string())?;
+    viewer_state.tabs.push(tab);
+    viewer_state.active = Some(ActiveTab { key });
     Ok(viewer_state.clone())
 }
 

--- a/src-tauri/src/utils/file_utils.rs
+++ b/src-tauri/src/utils/file_utils.rs
@@ -124,3 +124,25 @@ pub(crate) fn get_any_extensions() -> Vec<String> {
 pub(crate) fn normalize_path(path: &str) -> String {
     path.replace('\\', "/").to_lowercase()
 }
+
+/// フォルダ内の最初の画像ファイルのパスを返す
+/// 画像が見つからない場合は空文字列を返す
+pub(crate) fn find_first_image_in_folder(folder_path: &std::path::Path) -> String {
+    use std::fs::read_dir;
+
+    let extensions = get_image_extensions();
+
+    if let Ok(entries) = read_dir(folder_path) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let ext = path
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or_default();
+            if extensions.iter().any(|v| v == ext) {
+                return path.to_str().unwrap_or_default().to_string();
+            }
+        }
+    }
+    String::new()
+}

--- a/src-tauri/src/utils/watcher_utils.rs
+++ b/src-tauri/src/utils/watcher_utils.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use tauri::{AppHandle, Emitter, State};
 
 use crate::service::app_state::AppState;
+use crate::service::explorer_state::CachedDirEntry;
 
 /// ディレクトリ監視を開始するヘルパー関数
 ///
@@ -51,7 +52,7 @@ pub async fn unsubscribe_directory(
     let mut watchers_guard = state.watchers.lock().await;
 
     if let Some((_, ref_count)) = watchers_guard.get_mut(&dir_path) {
-        *ref_count -= 1;
+        *ref_count = ref_count.saturating_sub(1);
         if *ref_count == 0 {
             watchers_guard.remove(&dir_path);
         }
@@ -64,16 +65,25 @@ pub fn create_explorer_watcher_callback(
     app: AppHandle,
     path: String,
     cache: Arc<tokio::sync::RwLock<std::collections::HashMap<String, String>>>,
+    dir_list_cache: Arc<
+        tokio::sync::RwLock<std::collections::HashMap<String, Vec<CachedDirEntry>>>,
+    >,
 ) -> impl Fn(NotifyResult<Event>) + Send + 'static {
     move |res| match res {
         Ok(_) => {
-            // ディレクトリ変更時にキャッシュをクリア
+            // ディレクトリ変更時にサムネイルキャッシュとディレクトリリストキャッシュをクリア
             let cache_clone = cache.clone();
+            let dir_list_cache_clone = dir_list_cache.clone();
             let path_clone = path.clone();
             tokio::spawn(async move {
                 crate::service::explorer_state::clear_thumbnail_cache_for_dir(
                     &path_clone,
                     cache_clone,
+                )
+                .await;
+                crate::service::explorer_state::clear_dir_list_cache_for_dir(
+                    &path_clone,
+                    dir_list_cache_clone,
                 )
                 .await;
             });


### PR DESCRIPTION
## 概要

しばらくアプリを放置した後に発生する以下の全操作遅延を修正する。

- Explorer でアイテムを選択したとき（Viewer への反映が遅い）
- Viewer でページ移動したとき（操作不可になる）
- Explorer でチェックボタンによるフォルダ移動（移動と表示更新が遅い）

**根本原因**: `async` 関数内でブロッキング I/O（`read_dir`、`metadata`、`move_dir`、`get_file_tree` の再帰スキャン）を直接呼び出していた。アプリ放置後に OS が FS キャッシュを解放すると、`state.viewers.lock()` などの Mutex を保持したままディスク I/O が数秒走り、全コマンドがキューで待機する。

## 変更種別

- [ ] `feat` — 新機能
- [ ] `fix` — バグ修正
- [ ] `refactor` — リファクタリング（動作変更なし）
- [x] `perf` — パフォーマンス改善
- [ ] `docs` — ドキュメント・コメントのみの変更
- [ ] `chore` — ビルド設定・依存関係・その他

## 変更内容

### フロントエンド (SolidJS)

- 変更なし

### バックエンド (Rust)

- **`service/viewer_state.rs`** — `add_viewer_tab_state`: `viewers` Mutex を短時間だけ保持してタブキーを生成し解放。`spawn_blocking` で `get_file_tree`（再帰 FS スキャン）を実行後、Mutex を再取得してタブを追加
- **`app/viewer.rs`** — `refresh_viewer_tab_tree`: 必要情報を短時間ロックで取得 → ロック解放 → `spawn_blocking` で `rebuild_file_tree` → 再取得して状態更新
- **`service/explorer_state.rs`** — `scan_and_sort_dirs_sync` を新設（`read_dir` + `is_dir` + `metadata` + sort を集約した純粋な同期関数）。`explore_path_with_count` のキャッシュミス時に `spawn_blocking` 経由で呼び出すよう変更。`db` パラメータを `Option<&Database>` → `Option<Arc<Database>>` に変更（スレッド境界を越えられるように）
- **`app/explorer.rs`** — `transfer_folder`: `move_dir`（大容量フォルダ移動）を `spawn_blocking` に移動。全 `explore_path_with_count` 呼び出しを `Some(state.db.clone())` に更新

## 関連 Issue

- 

## テスト方法

1. アプリを起動し Explorer で 1000+ フォルダを含むディレクトリを開く
2. アプリを 10～30 分放置する（OS の FS キャッシュが解放される時間を待つ）
3. Explorer でフォルダをクリックして Viewer に反映されるまでの時間を確認（即応するはず）
4. Viewer でキーボードの左右キーによるページ移動が即応することを確認
5. Explorer でチェックボタンによるフォルダ移動が即応し、移動後の表示も即更新されることを確認

## スクリーンショット / 動画

| Before | After |
|--------|-------|
| 放置後の操作で数秒ブロック | 放置後も即応 |

## チェックリスト

### 共通

- [ ] `pnpm lint` でエラーなし
- [ ] `pnpm format` でフォーマット済み
- [x] 既存の動作に影響がないことを確認済み

### バックエンド (Rust 変更がある場合)

- [x] レイヤー分離原則を遵守している
  - `app/` — `#[tauri::command]` とイベント emit のみ
  - `service/` — 状態操作のみ（`AppHandle` 不使用）
  - `utils/` — 純粋なヘルパー関数のみ
- [x] Tauri コマンドは `Result<T, String>` を返している
- [x] 内部関数は `anyhow::Result` を使用している
- [x] Mutex/RwLock のデッドロックが発生しないことを確認済み
- [x] `#[serde(rename_all = "camelCase")]` の使用が適切
- [x] 新規コマンドを `lib.rs` の `invoke_handler` に登録済み（新規コマンドなし）

### フロントエンド (TypeScript 変更がある場合)

- N/A（フロントエンド変更なし）

## 補足事項

このブランチには 2 つのコミットが含まれます：

| コミット | 内容 |
|---|---|
| `07d32c0` | perf(explorer): add dir_list_cache to avoid full directory rescans |
| `09ad341` | perf: move blocking I/O out of async context to fix cold-cache slowdowns |

前者は Explorer のページング高速化（同一条件のディレクトリスキャンをキャッシュ）、後者が本 PR の主目的である「放置後の全操作遅延修正」です。